### PR TITLE
Added a missing comma in the README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Write your script like this:
         with ({a : "foo"}) {
           x = a;
         }
-      }
+      },
       "no wrapper" : function () {
         var a = "foo";
         var x = a;


### PR DESCRIPTION
Fixes a really minor detail in the README example (a missing comma).
It's important because many people will probably just try the example to make sure everything is working as expected.
