### PR TITLE
Using console.log instead of util.print

### DIFF
--- a/lib/bench.js
+++ b/lib/bench.js
@@ -135,7 +135,7 @@ function randomArray (l) {
   return knuth(a)
 }
 
-function print (m,cr) { util.print(m+(cr===false?"":"\n")); return print }
+function print (m,cr) { console.log(m+(cr===false?"":"\n")); return print }
 
 function show (results) {
   var averages = []


### PR DESCRIPTION
In node 0.11.12 a warning is displayed when using util.print.
